### PR TITLE
fix: different navigator used for auto pop

### DIFF
--- a/lib/motion_toast.dart
+++ b/lib/motion_toast.dart
@@ -440,7 +440,7 @@ class _MotionToastState extends State<MotionToast>
       widget.toastDuration,
       () {
         slideController.dispose();
-        Navigator.of(context, rootNavigator: true).pop();
+        Navigator.of(context).pop();
         toastTimer.cancel();
         widget.onClose?.call();
       },


### PR DESCRIPTION
## Changes
- Using same navigator to pop in auto and onTap

## Reason
- For auto dismiss, using root navigator results in popping of whole app

resolves #61