### PR TITLE
REFACTOR: removes warnings for Flutter < 3.0.0

### DIFF
--- a/lib/motion_toast.dart
+++ b/lib/motion_toast.dart
@@ -496,7 +496,16 @@ class _MotionToastState extends State<MotionToast>
         );
     }
 
-    WidgetsBinding.instance.addPostFrameCallback(
+    /// ! To support Flutter < 3.0.0
+    /// This allows a value of type T or T?
+    /// to be treated as a value of type T?.
+    ///
+    /// We use this so that APIs that have become
+    /// non-nullable can still be used with `!` and `?`
+    /// to support older versions of the API as well.
+    T? _ambiguate<T>(T? value) => value;
+
+    _ambiguate(WidgetsBinding.instance)?.addPostFrameCallback(
       (_) => slideController.forward(),
     );
   }


### PR DESCRIPTION
## Changes
- Adds recommended steps from official [Flutter docs](https://docs.flutter.dev/development/tools/sdk/release-notes/release-notes-3.0.0#your-code) to support `Flutter < 3.0.0`.