### PR TITLE
FIX: Vertical and Horizontal overflows in toast

### DIFF
--- a/lib/widgets/motion_toast_content.dart
+++ b/lib/widgets/motion_toast_content.dart
@@ -70,13 +70,16 @@ class MotionToastContent extends StatelessWidget {
         children: <Widget>[
           const Seperator.double(10),
           Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.end,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                if (title != null) title!,
-                description,
-              ],
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(vertical: 10),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  if (title != null) title!,
+                  description,
+                ],
+              ),
             ),
           ),
           const Seperator.double(15),
@@ -110,16 +113,23 @@ class MotionToastContent extends StatelessWidget {
         ),
         const Seperator.double(15),
         Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              if (title != null) title!,
-              description,
-            ],
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.only(
+              top: 10,
+              bottom: 10,
+              right: 8,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                if (title != null) title!,
+                description,
+              ],
+            ),
           ),
         ),
-        const Seperator.double(10),
+        const Seperator.double(7),
       ],
     );
   }

--- a/lib/widgets/motion_toast_content.dart
+++ b/lib/widgets/motion_toast_content.dart
@@ -68,25 +68,25 @@ class MotionToastContent extends StatelessWidget {
       return Row(
         mainAxisAlignment: MainAxisAlignment.end,
         children: <Widget>[
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              if (title != null) title!,
-              SizedBox(
-                width: width * 0.7,
-                child: description,
-              ),
-            ],
-          ),
           const Seperator.double(10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                if (title != null) title!,
+                description,
+              ],
+            ),
+          ),
+          const Seperator.double(15),
           MotionToastIcon(
             iconSize: iconSize,
             color: color,
             icon: icon,
             withAnimation: withAnimation,
           ),
-          const Seperator.double(20),
+          const Seperator.double(15),
           MotionToastSideBar(
             color: color,
             radius: radius,
@@ -101,25 +101,25 @@ class MotionToastContent extends StatelessWidget {
           color: color,
           radius: radius,
         ),
-        const Seperator.double(20),
+        const Seperator.double(15),
         MotionToastIcon(
           iconSize: iconSize,
           color: color,
           icon: icon,
           withAnimation: withAnimation,
         ),
+        const Seperator.double(15),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              if (title != null) title!,
+              description,
+            ],
+          ),
+        ),
         const Seperator.double(10),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            if (title != null) title!,
-            SizedBox(
-              width: width * 0.7,
-              child: description,
-            ),
-          ],
-        )
       ],
     );
   }


### PR DESCRIPTION
## Fix
- `description` widget overflows horizontally
- `description` widget overflows vertically

## Changes
- Wrapped **_contents_** of toast in `Expanded` widget to avoid horizontal overflow
- Wrapped **_contents_** of toast in `SingleChildScrollView` widget to avoid vertical overflow

Resolves #66 