### PR TITLE
FIX: parent widget pops with toast

### DIFF
--- a/lib/motion_toast.dart
+++ b/lib/motion_toast.dart
@@ -429,20 +429,22 @@ class _MotionToastState extends State<MotionToast>
   late AnimationController slideController;
   late Timer toastTimer;
 
+  void _popCurrentToast() {
+    if (mounted) {
+      Navigator.of(context).popUntil(
+        (route) => route.isCurrent,
+      );
+      widget.onClose?.call();
+    }
+  }
+
   @override
   void initState() {
     super.initState();
     _initializeAnimation();
     toastTimer = Timer(
       widget.toastDuration,
-      () {
-        if (mounted) {
-          Navigator.of(context).popUntil(
-            (route) => route.isCurrent,
-          );
-        }
-        widget.onClose?.call();
-      },
+      _popCurrentToast,
     );
   }
 
@@ -517,15 +519,7 @@ class _MotionToastState extends State<MotionToast>
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: widget.dismissable
-          ? () {
-              if (mounted) {
-                Navigator.of(context).popUntil(
-                  (route) => route.isCurrent,
-                );
-              }
-            }
-          : null,
+      onTap: widget.dismissable ? _popCurrentToast : null,
       child: Scaffold(
         backgroundColor: Colors.transparent,
         body: SafeArea(child: _buildToast()),

--- a/lib/motion_toast.dart
+++ b/lib/motion_toast.dart
@@ -436,9 +436,11 @@ class _MotionToastState extends State<MotionToast>
     toastTimer = Timer(
       widget.toastDuration,
       () {
-        slideController.dispose();
-        Navigator.of(context).pop();
-        toastTimer.cancel();
+        if (mounted) {
+          Navigator.of(context).popUntil(
+            (route) => route.isCurrent,
+          );
+        }
         widget.onClose?.call();
       },
     );
@@ -515,7 +517,15 @@ class _MotionToastState extends State<MotionToast>
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: widget.dismissable ? Navigator.of(context).pop : null,
+      onTap: widget.dismissable
+          ? () {
+              if (mounted) {
+                Navigator.of(context).popUntil(
+                  (route) => route.isCurrent,
+                );
+              }
+            }
+          : null,
       child: Scaffold(
         backgroundColor: Colors.transparent,
         body: SafeArea(child: _buildToast()),
@@ -623,10 +633,8 @@ class _MotionToastState extends State<MotionToast>
 
   @override
   void dispose() {
-    if (toastTimer.isActive) {
-      slideController.dispose();
-      toastTimer.cancel();
-    }
+    slideController.dispose();
+    toastTimer.cancel();
     super.dispose();
   }
 }


### PR DESCRIPTION
## Changes
- Only pop till the current route (i.e. toast widget) is at the top
- Check if toast widget is mounted before trying to pop

# Note
This change seems to pass the integration test. Also I have tried it on many other examples and it seems to work fine.

However, I have **NO** idea how it works. It might also cause crashes.

Resolves #72, might resolve #78 