### PR TITLE
Fix the issue related to the toast width and make it responsive with tablets also.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -281,6 +281,8 @@ class _HomePageState extends State<HomePage> {
 
   void _displayCustomMotionToast() {
     MotionToast(
+      width: MediaQuery.of(context).size.width * 0.75,
+      height: MediaQuery.of(context).size.height * 0.10,
       primaryColor: Colors.pink,
       title: const Text(
         'Bugatti',

--- a/lib/motion_toast.dart
+++ b/lib/motion_toast.dart
@@ -444,7 +444,22 @@ class MotionToast extends StatefulWidget {
             contentPadding: const EdgeInsets.all(0),
             insetPadding: const EdgeInsets.all(30),
             elevation: 0,
-            content: this,
+            content: Align(
+              alignment: position.alignment,
+              child: Container(
+                height: height,
+                width: width,
+                constraints: height == null && width == null
+                    ? constraints ??
+                        BoxConstraints(
+                          maxWidth: MediaQuery.of(context).size.width * 0.75,
+                          minWidth: 200,
+                          maxHeight: 100,
+                        )
+                    : null,
+                child: this,
+              ),
+            ),
           ),
         );
       },
@@ -560,27 +575,12 @@ class _MotionToastState extends State<MotionToast>
 
   Widget _renderMotionToastContent() {
     return Center(
-      child: Align(
-        alignment: widget.position.alignment,
-        child: Container(
-          height: widget.height,
-          width: widget.width,
-          constraints: widget.height == null && widget.width == null
-              ? widget.constraints ??
-                  BoxConstraints(
-                    maxWidth: MediaQuery.of(context).size.width * 0.75,
-                    minWidth: 200,
-                    maxHeight: 100,
-                  )
-              : null,
-          child: widget.position == MotionToastPosition.center
-              ? _buildMotionToast()
-              : SlideTransition(
-                  position: offsetAnimation,
-                  child: _buildMotionToast(),
-                ),
-        ),
-      ),
+      child: widget.position == MotionToastPosition.center
+          ? _buildMotionToast()
+          : SlideTransition(
+              position: offsetAnimation,
+              child: _buildMotionToast(),
+            ),
     );
   }
 


### PR DESCRIPTION
Hi,
I have faced a problem with the package: 
when setting the 'width' prosperity in any type of the toast, it has no effect at all which causes a problem with large size devices like 10-inch tablets.

I have edited the code for solving the issue and it works now!

**Before Editing:**
&nbsp;
<img src=https://github.com/user-attachments/assets/ac6d4f72-400c-47a1-8b52-088530f3051f
  width="250" height = "500" alt=Image description> &ensp;
&nbsp;
&nbsp;
**After Editing:**
&nbsp;
  <img src=https://github.com/user-attachments/assets/d5847311-c42b-4b94-b103-09200e70cd09
  width="250" height = "500"/> &ensp;




